### PR TITLE
fix(ENGCC-618): Fixed typo in multiversx name

### DIFF
--- a/config.js
+++ b/config.js
@@ -3,12 +3,12 @@ module.exports = {
         main: {
             provider: "https://gateway.multiversx.com",
             transactionLink: (hash) => `https://explorer.multiversx.com/transactions/${hash}`,
-            walletLink: (address) => `https://explorer.multiversex.com/address/${address}`,
+            walletLink: (address) => `https://explorer.multiversx.com/address/${address}`,
             networkName: "main",
         },
         testnet: {
             provider: "https://testnet-gateway.multiversx.com",
-            transactionLink: (hash) => `https://testnet-explorer.multiversex.com/transactions/${hash}`,
+            transactionLink: (hash) => `https://testnet-explorer.multiversx.com/transactions/${hash}`,
             walletLink: (address) => `https://testnet-explorer.multiversx.com/address/${address}`,
             networkName: "testnet",
         },


### PR DESCRIPTION
There was a typo in multiversx name for walletLink and transactionLink we are generating. Update the link to correct website